### PR TITLE
- optional store argument

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,11 +2,21 @@ const { METHODS } = require('http');
 const findMyWay = require('find-my-way');
 const compose = require('koa-compose');
 
+
 module.exports = function router(options) {
   const fmw = findMyWay(options);
   const r = {};
 
   function on(method, path, ...middlewares) {
+    // optional store argument
+    let store;
+    if (middlewares.length > 1 && typeof middlewares[middlewares.length - 1] === 'object') {
+      store = middlewares.pop();
+      middlewares.unshift(async (ctx, next) => {
+        ctx.store = store;
+        await next();
+      });
+    }
     fmw.on(method, path, compose(middlewares));
     return r;
   }

--- a/test/koa-router-find-my-way.test.js
+++ b/test/koa-router-find-my-way.test.js
@@ -24,6 +24,23 @@ it('router with koa', async () => {
       };
       await next();
     });
+
+  router
+    .get('/store/one', async (ctx, next) => {
+      const { s } = ctx.store;
+      ctx.body = {
+        s,
+      };
+      await next();
+    }, { s: 'test-one' })
+    .get('/store/two', async (ctx, next) => next(), async (ctx, next) => {
+      const { s } = ctx.store;
+      ctx.body = {
+        s,
+      };
+      await next();
+    }, { s: 'test-two' });
+
   app.use(router.routes());
   app.listen(34567);
 
@@ -36,5 +53,13 @@ it('router with koa', async () => {
 
   expect(await got('http://localhost:34567/all/def').json()).toEqual({
     p: 'def',
+  });
+
+  expect(await got('http://localhost:34567/store/one').json()).toEqual({
+    s: 'test-one',
+  });
+
+  expect(await got('http://localhost:34567/store/two').json()).toEqual({
+    s: 'test-two',
   });
 });


### PR DESCRIPTION
fmw's on signature is as [follows](https://github.com/delvedor/find-my-way#onmethod-path-opts-handler-store)

````
on(method, path, [opts], handler, [store])
````

Theres's a [store] argument which is useful to pass parameters into the middleware. The patch adds support to it. As this module supports veridic middleware array (which is a good idea), the support is added during the argument parsing.

There's also an [opts] argument, which is documented but not explained in fmw. Ignored for now.
